### PR TITLE
Added Swagger docs

### DIFF
--- a/django_app/settings.py
+++ b/django_app/settings.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
+    'rest_framework_swagger',
 ]
 
 MIDDLEWARE = [
@@ -143,13 +144,20 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 REST_FRAMEWORK = {
-    'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.AllowAny', ],
+    'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated', ],
     'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.TokenAuthentication',
                                        'rest_framework.authentication.SessionAuthentication', ],
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 10
 }
+
+SWAGGER_SETTINGS = {
+    'USE_SESSION_AUTH': 'False',
+}
+
+LOGOUT_URL = 'rest_framework:logout'
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/

--- a/django_app/settings.py
+++ b/django_app/settings.py
@@ -157,8 +157,6 @@ SWAGGER_SETTINGS = {
     'USE_SESSION_AUTH': 'False',
 }
 
-LOGOUT_URL = 'rest_framework:logout'
-
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
 

--- a/django_app/urls.py
+++ b/django_app/urls.py
@@ -15,17 +15,15 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from django.http import JsonResponse
+from rest_framework_swagger.views import get_swagger_view
+from django.conf.urls import url
 
-
-def home(request):
-    return JsonResponse({"hello": "world!"})
-
+schema_view = get_swagger_view(title='Rules as a Service API')
 
 urlpatterns = [
-    path('', home, name='home'),
     path('admin/', admin.site.urls),
     path('api/', include('toastapi.urls')),
     path('auth/', include('rest_auth.urls')),
     path('auth/registration', include('rest_auth.registration.urls')),
+    url(r'^$', schema_view),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ django-allauth
 django-heroku
 pytest
 pytest-django
+django-rest-swagger


### PR DESCRIPTION
- [x] Only exposes /auth endpoints to browse anonymously
- [x] Once authenticated, all `toastapi` endpoints become available to browse and make requests

Closes #124